### PR TITLE
ensure_packages on screen

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,9 +5,7 @@ class nexpose::install (
 
 ) {
 
-  package { 'screen':
-    ensure => present,
-  }
+  ensure_packages(['screen'], {'ensure' => 'latest'})
 
   file { 'rapid7_directory':
     ensure => directory,


### PR DESCRIPTION
This stdlib function accomplishes the same thing as the package resource, but prevents duplicate declarations in the catalog in the case that the `screen` package is already managed elsewhere.